### PR TITLE
Add option to launch multiple files

### DIFF
--- a/autostarter.lua
+++ b/autostarter.lua
@@ -9,7 +9,7 @@ function script_properties()
 
 	local props = obs.obs_properties_create()
 	
-	obs.obs_properties_add_path(props, "execPath", "File", obs.OBS_PATH_FILE, "*.exe, *.vbs, *.bat, *.lnk, *.*", nil)
+	obs.obs_properties_add_editable_list(props, "execPaths", "Executables", obs.OBS_EDITABLE_LIST_TYPE_FILES, "*.exe, *.vbs, *.bat, *.lnk, *.*", nil)
 
 	obs.obs_properties_add_bool(props, "boolAutoquit", "Autoclose on OBS quit? \n(Only works with .exe)")
 
@@ -49,37 +49,62 @@ end
 function script_unload()
 
 	-- assemble command		
-
 	if obs.obs_data_get_bool(localSettings, "boolAutoquit") then 
-		cmd = 'taskkill /IM "' .. execName .. '"'
-		-- execute command
-		os.execute(cmd)
-	end
+		local execPaths = obs.obs_data_get_array(localSettings, 'execPaths')
+		local count = obs.obs_data_array_count(execPaths)
+
+		for i = 0, count do 	
+			local item = obs.obs_data_array_item(execPaths, i)
+			local execPath = obs.obs_data_get_string(item, "value")
+
+			-- replace / by \
+			execPath = execPath:gsub("/","\\")
 	
+			-- only proceed if there is a  file selected
+			if execPath == '' then return nil end
+		
+			-- get Executable
+			local index = execPath:match'^.*()\\'
+			local execName = execPath:sub(index + 1, execPath:len())
+		
+			-- assemble command
+			local cmd = 'taskkill /IM "' .. execName .. '"'
+			
+			-- execute command
+			os.execute(cmd)
+		end 
+	end
 end
 
 function launch_func()
+	local execPaths = obs.obs_data_get_array(localSettings, 'execPaths')
+	local count = obs.obs_data_array_count(execPaths)
 
-	execPath = obs.obs_data_get_string(localSettings, "execPath")
-	-- replace / by \
-	execPath = execPath:gsub("/","\\")
-
-	-- obs.script_log(obs.LOG_INFO, execPath)
-	
-	-- only proceed if there is a  file selected
-	if execPath == '' then return nil end
-	
-	-- get Directory
-	index = execPath:match'^.*()\\'
-	execDir = execPath:sub(1,index)
-	
-	-- get Executable
-	execName = execPath:sub(index + 1, execPath:len())
-	
-	-- assemble command
-	cmd = 'start "" /D "' .. execDir .. '" "' .. execName .. '"'
+	for i = 0, count do 	
+        local item = obs.obs_data_array_item(execPaths, i)
+        local execPath = obs.obs_data_get_string(item, "value")
 		
-	-- execute command
-	os.execute(cmd)
+		-- replace / by \
+		execPath = execPath:gsub("/","\\")
+	
+		-- obs.script_log(obs.LOG_INFO, execPath)
+		
+		-- only proceed if there is a  file selected
+		if execPath == '' then return nil end
+		
+		-- get Directory
+		local index = execPath:match'^.*()\\'
+		local execDir = execPath:sub(1,index)
+		
+		-- get Executable
+		local execName = execPath:sub(index + 1, execPath:len())
+		
+		-- assemble command
+		local cmd = 'start "" /D "' .. execDir .. '" "' .. execName .. '"'
+			
+		-- execute command
+		os.execute(cmd)
+	end
 
+	obs.obs_data_array_release(execPaths)
 end


### PR DESCRIPTION
Changed obs.obs_properties_add_path to obs.obs_properties_add_editable_list in order to be able to launch multiple files instead of one.